### PR TITLE
fix: try close #10

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,10 +351,8 @@ impl CharacterProbability {
         let mut s = String::new();
 
         for i in &self.probability {
-            let n = i
-                .iter()
-                .position(|v| v == i.iter().max_by(|a, b| a.total_cmp(b)).unwrap())
-                .unwrap();
+            let max = i.iter().max_by(|a, b| a.total_cmp(b)).unwrap();
+            let n = i.iter().position(|v| v == max).unwrap();
 
             s += &self.charset[n];
         }


### PR DESCRIPTION
如代码所说，每次执行闭包的复杂度是 O(n^2) 的，但是在 `get_text` 内 `self.probability` 的内容应当是不会改变的，故其最大值是确定的。先求出最大值再扔进闭包里应当可以将复杂度降至 O(n)

~~我很奇怪这个代码 Rust 为什么没有在编译时优化掉~~

同时，https://github.com/86maid/ddddocr/blob/196854dc34669ce72b9e2d9fedefdc6a929d56c6/src/lib.rs#L268 函数看起来现在变成了可以优化的瓶颈，也许可以考虑让用户传参而非程序来判断模型类型？

附图，修改后的 perf report:

![image](https://github.com/86maid/ddddocr/assets/29979060/f79074c2-66d6-494c-85a5-52e5eb08b74a)
