### PR TITLE
支持了静态编译，不用管烦人的dll了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,15 @@ name = "ddddocr"
 version = "0.3.0"
 edition = "2021"
 
-[features]
-cuda = ["onnxruntime/cuda"]
+[lib]
+name = "ddddocr"
+crate-type = ["rlib"]
 
 [dependencies]
 # 我把 ureq 改成了 reqwest，因为他不支持代理，导致下载经常失败
-onnxruntime = { git = "https://github.com/86maid/onnxruntime-rs.git", branch = "master" }
-# 这个版本不支持 cuda
-# onnxruntime = "0.0.14"
+ort = { version = "2.0.0-rc.2" }
+ndarray = "0.15"
+
 lazy_static = "1.4.0"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"


### PR DESCRIPTION
#### onnxruntime-rs 0.0.14 (onnxruntime 1.8.0) update to ort 2.0.0-rc.2v (onnxruntime 1.18.0)

### ort 绑定了 onnxruntime的接口，同时提供了一些有助于rust工程化的特性
- 现在可以指定动态链接或静态链接，可以选择怎么打包喽
- 根据features启用各平台的专属优化功能，具体可看ort文档
- tensor有一些新特性，我怕改了报错，所以代码里只做了最小化修改
- 取消了Environment这个概念，毕竟他本来就是个单线程全局的东西，就不应该被当作结构体


### 最关键的是，onnxruntime-rs总算能得到持续维护喽